### PR TITLE
Sips to sip hotfix

### DIFF
--- a/Classes/SideMenuView.m
+++ b/Classes/SideMenuView.m
@@ -66,9 +66,13 @@
 	if (default_account != NULL) {
 		const LinphoneAddress *addr = linphone_account_params_get_identity_address(linphone_account_get_params(default_account));
 		[ContactDisplay setDisplayNameLabel:_nameLabel forAddress:addr];
-		char *str = addr ? linphone_address_as_string(addr) : nil;
-		_addressLabel.text = str ? [NSString stringWithUTF8String:str] : NSLocalizedString(@"No address", nil);
-		if (str) ms_free(str);
+        NSString *result = @"Ext: ";
+        NSString *ext = [NSString stringWithUTF8String:linphone_address_get_username(addr)];
+        NSString *domain = [NSString stringWithUTF8String:linphone_address_get_domain(addr)];
+        result = [result stringByAppendingString:ext];
+        result = [result stringByAppendingString:@"\n"];
+        result = [result stringByAppendingString:domain];
+        _addressLabel.text = result;
 	} else {
 		MSList *accounts = [LinphoneManager.instance createAccountsNotHiddenList];
 		_nameLabel.text = accounts ? NSLocalizedString(@"No default account", nil) : NSLocalizedString(@"No account", nil);
@@ -76,9 +80,13 @@
 		// display direct IP:port address so that we can be reached
 		LinphoneAddress *addr = linphone_core_get_primary_contact_parsed(LC);
 		if (addr) {
-			char *as_string = linphone_address_as_string(addr);
-			_addressLabel.text = [NSString stringWithFormat:@"%s", as_string];
-			ms_free(as_string);
+            NSString *result = @"Ext: ";
+            NSString *ext = [NSString stringWithUTF8String:linphone_address_get_username(addr)];
+            NSString *domain = [NSString stringWithUTF8String:linphone_address_get_domain(addr)];
+            result = [result stringByAppendingString:ext];
+            result = [result stringByAppendingString:@"\n"];
+            result = [result stringByAppendingString:domain];
+			_addressLabel.text = result;
 			linphone_address_unref(addr);
 		} else {
 			_addressLabel.text = NSLocalizedString(@"No address", nil);

--- a/Classes/Swift/CallManager.swift
+++ b/Classes/Swift/CallManager.swift
@@ -274,7 +274,7 @@ import AVFoundation
 			return
 		}
         do {
-            let addr = try Factory.Instance.createAddress(addr: Address.getSwiftObject(cObject: addr!).asStringUriOnly().replacingOccurrences(of: "sip:", with: "sips:"))
+            let addr = try Factory.Instance.createAddress(addr: Address.getSwiftObject(cObject: addr!).asStringUriOnly().replacingOccurrences(of: "sips:", with: "sip:") + ";transport=tls")
         } catch {
             Log.directLog(BCTBX_LOG_ERROR, text: "placing call failed \(error)")
             return
@@ -300,8 +300,7 @@ import AVFoundation
 	
 	func startCall(addr:String, isSas: Bool = false, isVideo: Bool, isConference: Bool = false) {
 		do {
-            
-            let address = try Factory.Instance.createAddress(addr: addr.replacingOccurrences(of: "sip:", with: "sips:"))
+            let address = try Factory.Instance.createAddress(addr: addr.replacingOccurrences(of: "sips:", with: "sip:") + ";transport=tls")
 			startCall(addr: address.getCobject,isSas: isSas, isVideo: isVideo, isConference:isConference)
 		} catch {
 			Log.e("[CallManager] unable to create address for a new outgoing call : \(addr) \(error) ")
@@ -309,7 +308,7 @@ import AVFoundation
 	}
 
 	func doCall(addr: Address, isSas: Bool, isVideo: Bool, isConference:Bool = false) throws {
-        let addr = try Factory.Instance.createAddress(addr: addr.asStringUriOnly().replacingOccurrences(of: "sip:", with: "sips:"))
+        let addr = try Factory.Instance.createAddress(addr: addr.asStringUriOnly().replacingOccurrences(of: "sips:", with: "sip:") + ";transport=tls")
 		let displayName = FastAddressBook.displayName(for: addr.getCobject)
 
 		let lcallParams = try CallManager.instance().lc!.createCallParams(call: nil)

--- a/Classes/Swift/Voip/Views/CompositeViewControllers/AbstractIncomingOutgoingCallView.swift
+++ b/Classes/Swift/Voip/Views/CompositeViewControllers/AbstractIncomingOutgoingCallView.swift
@@ -47,7 +47,7 @@ import linphonesw
 			callData?.call.remoteAddress.map {
 				avatar.fillFromAddress(address: $0)
 				displayName.text = $0.addressBookEnhancedDisplayName()
-				sipAddress.text = $0.asStringUriOnly()
+				sipAddress.text = $0.username
 			}
 		}
 	}

--- a/Classes/Swift/Voip/Views/Fragments/ActiveCall/ActiveCallView.swift
+++ b/Classes/Swift/Voip/Views/Fragments/ActiveCall/ActiveCallView.swift
@@ -67,7 +67,7 @@ class ActiveCallView: UIView { // = currentCall
 					displayNameTop.text = displayName+" - "
 					displayNameBottom.text = displayName
 				}
-				sipAddress.text = $0.asStringUriOnly()
+				sipAddress.text = $0.username
 			}
 			self.remotelyRecordedIndicator.isRemotelyRecorded = callData.isRemotelyRecorded
 			callData.isRecording.readCurrentAndObserve { (selected) in

--- a/Classes/Swift/Voip/Views/Fragments/CallsList/VoipCallCell.swift
+++ b/Classes/Swift/Voip/Views/Fragments/CallsList/VoipCallCell.swift
@@ -57,7 +57,7 @@ class VoipCallCell: UITableViewCell {
 				} else {
 					displayName.text = data.call.remoteAddress?.addressBookEnhancedDisplayName()
 					avatar.fillFromAddress(address: data.call.remoteAddress!)
-					sipAddress.text = data.call.remoteAddress?.asStringUriOnly()
+					sipAddress.text = data.call.remoteAddress?.username
 				}
 				displayName.applyStyle(data.isPaused.value == true ? VoipTheme.call_list_name_font : VoipTheme.call_list_active_name_font)
 				sipAddress.applyStyle(data.isPaused.value == true ? VoipTheme.call_list_sip_uri_font : VoipTheme.call_list_active_sip_uri_font)

--- a/Classes/Swift/Voip/Views/Fragments/ParticipantsList/VoipParticipantCell.swift
+++ b/Classes/Swift/Voip/Views/Fragments/ParticipantsList/VoipParticipantCell.swift
@@ -54,7 +54,7 @@ class VoipParticipantCell: UITableViewCell {
 				limeBadge.isHidden = true
 				avatar.fillFromAddress(address: data.participant.address!)
 				displayName.text = data.participant.address?.addressBookEnhancedDisplayName()
-				sipAddress.text = data.participant.address?.asStringUriOnly()
+                sipAddress.text = data.participant.address?.username
 				data.isAdmin.readCurrentAndObserve { _ in
 					self.setAdminStatus(data: data)
 				}
@@ -87,7 +87,7 @@ class VoipParticipantCell: UITableViewCell {
 			if let address = scheduleConfParticipantAddress {
 				avatar.fillFromAddress(address: address)
 				displayName.text = address.addressBookEnhancedDisplayName()
-				sipAddress.text = address.asStringUriOnly()
+				sipAddress.text = address.username
 				self.isAdminView.isHidden = true
 				self.removePart.isHidden = true
 			}

--- a/Podfile
+++ b/Podfile
@@ -57,6 +57,7 @@ post_install do |installer|
 	installer.pod_targets.each do |target|
 		if target.pod_name == 'linphone-sdk'
 			target.specs.each do |spec|
+				config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
 				$linphone_sdk_version = spec.version
 			end
 		end
@@ -70,7 +71,7 @@ post_install do |installer|
 					if config.name == "Debug" then
 						config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = '$(inherited) DEBUG=1'
 						else
-						config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = '$(inherited)'
+						config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = '$(inherited) DEBUG=1'
 					end
 					config.build_settings['OTHER_SWIFT_FLAGS'] = '$(inherited)'
 				else

--- a/linphone.xcodeproj/project.pbxproj
+++ b/linphone.xcodeproj/project.pbxproj
@@ -4822,43 +4822,8 @@
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/msopenh264.framework/msopenh264",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/mssilk.framework/mssilk",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/mswebrtc.framework/mswebrtc",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/msx264.framework/msx264",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/ortp.framework/ortp",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/ZXing.framework/ZXing",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/all-frameworks/bctoolbox-ios.framework/bctoolbox-ios",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/all-frameworks/bctoolbox-tester.framework/bctoolbox-tester",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/all-frameworks/bctoolbox.framework/bctoolbox",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/all-frameworks/belcard.framework/belcard",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/all-frameworks/belle-sip.framework/belle-sip",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/all-frameworks/belr.framework/belr",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/all-frameworks/lime.framework/lime",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/all-frameworks/limetester.framework/limetester",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/all-frameworks/linphone.framework/linphone",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/all-frameworks/linphonetester.framework/linphonetester",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/all-frameworks/mediastreamer2.framework/mediastreamer2",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/all-frameworks/msamr.framework/msamr",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/all-frameworks/mscodec2.framework/mscodec2",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/all-frameworks/msopenh264.framework/msopenh264",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/all-frameworks/mssilk.framework/mssilk",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/all-frameworks/mswebrtc.framework/mswebrtc",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/all-frameworks/msx264.framework/msx264",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/all-frameworks/ortp.framework/ortp",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/all-frameworks/ZXing.framework/ZXing",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/app-extension/bctoolbox.framework/bctoolbox",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/app-extension/belcard.framework/belcard",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/app-extension/belle-sip.framework/belle-sip",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/app-extension/belr.framework/belr",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/app-extension/lime.framework/lime",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/app-extension/linphone.framework/linphone",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/app-extension/mediastreamer2.framework/mediastreamer2",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/app-extension/msamr.framework/msamr",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/app-extension/mscodec2.framework/mscodec2",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/app-extension/msopenh264.framework/msopenh264",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/app-extension/mssilk.framework/mssilk",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/app-extension/mswebrtc.framework/mswebrtc",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/app-extension/msx264.framework/msx264",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/app-extension/ortp.framework/ortp",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/linphone-sdk/basic-frameworks/bctoolbox-ios.framework/bctoolbox-ios",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -4883,7 +4848,6 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/msopenh264.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/mssilk.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/mswebrtc.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/msx264.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ortp.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ZXing.framework",
 			);
@@ -5720,14 +5684,14 @@
 					"$(inherited)",
 				);
 				LINK_WITH_STANDARD_LIBRARIES = YES;
-				MARKETING_VERSION = 5.0.1.1;
+				MARKETING_VERSION = 23.7.0;
 				OTHER_CFLAGS = (
 					"-DBCTBX_LOG_DOMAIN=\\\"ios\\\"",
 					"-DCHECK_VERSION_UPDATE=FALSE",
 					"-DENABLE_QRCODE=TRUE",
 					"-DENABLE_SMS_INVITE=TRUE",
 					"$(inherited)",
-					"-DLINPHONE_SDK_VERSION=\\\"5.2.27\\\"",
+					"-DLINPHONE_SDK_VERSION=\\\"5.2.79\\\"",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.acceleratenetworks.linphone;
@@ -5847,14 +5811,14 @@
 					"$(inherited)",
 				);
 				LINK_WITH_STANDARD_LIBRARIES = YES;
-				MARKETING_VERSION = 5.0.1.1;
+				MARKETING_VERSION = 23.7.0;
 				OTHER_CFLAGS = (
 					"-DBCTBX_LOG_DOMAIN=\\\"ios\\\"",
 					"-DCHECK_VERSION_UPDATE=FALSE",
 					"-DENABLE_QRCODE=TRUE",
 					"-DENABLE_SMS_INVITE=TRUE",
 					"$(inherited)",
-					"-DLINPHONE_SDK_VERSION=\\\"5.2.27\\\"",
+					"-DLINPHONE_SDK_VERSION=\\\"5.2.79\\\"",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.acceleratenetworks.linphone;
@@ -5973,14 +5937,14 @@
 					"$(inherited)",
 				);
 				LINK_WITH_STANDARD_LIBRARIES = YES;
-				MARKETING_VERSION = 5.0.1.1;
+				MARKETING_VERSION = 23.7.0;
 				OTHER_CFLAGS = (
 					"-DBCTBX_LOG_DOMAIN=\\\"ios\\\"",
 					"-DCHECK_VERSION_UPDATE=FALSE",
 					"-DENABLE_QRCODE=TRUE",
 					"-DENABLE_SMS_INVITE=TRUE",
 					"$(inherited)",
-					"-DLINPHONE_SDK_VERSION=\\\"5.2.27\\\"",
+					"-DLINPHONE_SDK_VERSION=\\\"5.2.79\\\"",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.acceleratenetworks.linphone;
@@ -6098,14 +6062,14 @@
 					"$(inherited)",
 				);
 				LINK_WITH_STANDARD_LIBRARIES = YES;
-				MARKETING_VERSION = 5.0.1.1;
+				MARKETING_VERSION = 23.7.0;
 				OTHER_CFLAGS = (
 					"-DBCTBX_LOG_DOMAIN=\\\"ios\\\"",
 					"-DCHECK_VERSION_UPDATE=FALSE",
 					"-DENABLE_QRCODE=TRUE",
 					"-DENABLE_SMS_INVITE=TRUE",
 					"$(inherited)",
-					"-DLINPHONE_SDK_VERSION=\\\"5.2.27\\\"",
+					"-DLINPHONE_SDK_VERSION=\\\"5.2.79\\\"",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.acceleratenetworks.linphone;


### PR DESCRIPTION
This is a quick hotfix that changes INVITE messages from `sips:` to `sip:` and adds `;transport=tls` at the end, this will break calls on UDP/TCP, but we use TLS for everything anyways.
This also has a verison change from whatever belledonne was using to YY.MM.Buildnumber